### PR TITLE
feat(nestedStack): Set name for nested stack

### DIFF
--- a/packages/aws-cdk-lib/core/lib/nested-stack.ts
+++ b/packages/aws-cdk-lib/core/lib/nested-stack.ts
@@ -75,6 +75,13 @@ export interface NestedStackProps {
    * @default - No description.
    */
   readonly description?: string;
+
+  /**
+   * Name to deploy the stack with
+   *
+   * @default - Derived from construct path.
+   */
+  readonly stackName?: string;
 }
 
 /**
@@ -121,6 +128,7 @@ export class NestedStack extends Stack {
       synthesizer: new NestedStackSynthesizer(parentStack.synthesizer),
       description: props.description,
       crossRegionReferences: parentStack._crossRegionReferences,
+      stackName: props.stackName
     });
 
     this._parentStack = parentStack;


### PR DESCRIPTION
add stackName as a property under NestedStackProps and use it when initiating the stack super

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
